### PR TITLE
correct parallex on small screen developers page

### DIFF
--- a/content/themes/biojs-theme/assets/sass/layout.scss
+++ b/content/themes/biojs-theme/assets/sass/layout.scss
@@ -91,7 +91,7 @@ a[href]{
 nav {
   position: fixed;
   z-index: 9999;
-  
+
   .brand-logo {
     position: absolute;
     display: inline-block;
@@ -175,10 +175,10 @@ nav {
   }
 
 @media only screen and (max-width : 992px) {
-  .parallax-container .section {
-    position: absolute;
-    top: 40%;
-  }
+  // .parallax-container .section {
+  //   position: absolute;
+  //   top: 40%;
+  // }
   #index-banner .section {
     top: 10%;
   }


### PR DESCRIPTION
There is a UI bug on https://biojsnet.herokuapp.com/developers/ related to failure of parallax element for small screen devices : 
<img width="320" alt="screen shot 2016-04-08 at 2 39 29 am" src="https://cloud.githubusercontent.com/assets/6918450/14367106/d4d8aad0-fd33-11e5-9157-073a0666f193.png">

PR make it correct as : 
<img width="323" alt="screen shot 2016-04-08 at 2 40 28 am" src="https://cloud.githubusercontent.com/assets/6918450/14367130/f6d3ee1a-fd33-11e5-963b-0ac897923406.png">

@greenify @daviddao @jessica-jordan @DennisSchwartz  . Please take a look. 
